### PR TITLE
Add plugin_example to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8
 
 # Install Python dependencies
 COPY requirements.txt /app/
+COPY plugin_example/ app/plugin_example/
 WORKDIR /app
 RUN pip install -i https://pypi.douban.com/simple -r requirements.txt
 


### PR DESCRIPTION
Add the plugin example content in order to successfully build the web image.
Fix the following error:

`ERROR: ./plugin_example is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with svn+, git+, hg+, or bzr+).

ERROR: Service 'web' failed to build : The command '/bin/sh -c pip install -i https://pypi.douban.com/simple/ -r requirements.txt' returned a non-zero code: 1
`