### PR TITLE
Enable SQLite `db_type` in both app and test

### DIFF
--- a/flaskshop/settings.py
+++ b/flaskshop/settings.py
@@ -7,7 +7,7 @@ from flask.helpers import get_debug_flag
 
 
 class DBConfig:
-    db_type = os.getenv("DB_TYPE", "mysql")
+    db_type = os.getenv("DB_TYPE", "sqlite")
     user = os.getenv("DB_USER", "root")
     passwd = os.getenv("DB_PASSWD", "123456")
     host = os.getenv("DB_HOST", "127.0.0.1")
@@ -19,6 +19,14 @@ class DBConfig:
         db_uri = (
             f"mysql+pymysql://{user}:{passwd}@{host}:{port}/{db_name}?charset=utf8mb4"
         )
+    elif db_type == "sqlite":
+        basedir = Path(__file__).resolve().parent
+        DATABASE = "flaskr.db"
+        url = f"sqlite:///{Path(basedir).joinpath(DATABASE)}"
+        if url.startswith("postgres://"):
+            url = url.replace("postgres://", "postgresql://", 1)
+        db_uri = url
+
     redis_uri = "redis://localhost:6379"
     esearch_uri = "localhost"
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,9 +1,16 @@
 """Settings module for test app."""
 ENV = "development"
 TESTING = True
-SQLALCHEMY_DATABASE_URI = (
-    "mysql+pymysql://root:root@127.0.0.1:3306/testshop?charset=utf8mb4"
-)
+
+from pathlib import Path
+import os
+basedir = Path(__file__).resolve().parent
+DATABASE = "flaskr.db"
+url = os.getenv("DATABASE_URL", f"sqlite:///{Path(basedir).joinpath(DATABASE)}")
+if url.startswith("postgres://"):
+    url = url.replace("postgres://", "postgresql://", 1)
+SQLALCHEMY_DATABASE_URI = url
+
 SECRET_KEY = "not-so-secret-in-tests"
 BCRYPT_LOG_ROUNDS = (
     4  # For faster tests; needs at least 4 to avoid "ValueError: Invalid rounds"


### PR DESCRIPTION
This PR aims to enable SQLite `db_type` in both flask app and pytest. The final code runs without bugs and passes all 16 tests.

### Issue:
When running in an environment where no database type (MySQL, Postgresql, etc.) is configured, the project will fail at the database setup. For my Windows11, I did not download MySQL and thus opening my `services.msc` results in no service on MySQL. This will lead to `Can't connect to MySQL server on '127.0.0.1' ([WinError 10061] 由于目标计算机积极拒绝，无法连接。` in English would be `The error (2003) Can't connect to MySQL server on 'server' (10061) indicates that the network connection has been refused`.

### How do I fix:
I modified the settings.py to allow a SQLite database type and I set the default `db_type` to SQLite. After solving this, users could run the project without downloading any database services.

Below is the code snippet of changes:

![image](https://github.com/user-attachments/assets/fbd3e9c5-6db2-4fb5-91e1-a44ac93e1d5a)

